### PR TITLE
Run bandit when *.py files are present

### DIFF
--- a/lib/modules/python-bandit/__tests__/sample/requirements.txt
+++ b/lib/modules/python-bandit/__tests__/sample/requirements.txt
@@ -1,4 +1,0 @@
-requests
-cryptography
-insecure-package==0.1
-django>1.9.0<1.9.13

--- a/lib/modules/python-bandit/index.js
+++ b/lib/modules/python-bandit/index.js
@@ -12,15 +12,15 @@ module.exports = {
   description: 'Scans for common security issues in Python code with bandit.',
   enabled: true,
   handles: async fm => {
-    const hasRequirementsFile = fm.exists('requirements.txt')
+    const isPythonProject = fm.all().some(file => file.endsWith('.py'))
     const hasCommand = await exec.exists('bandit')
-    if (hasRequirementsFile && !hasCommand) {
-      logger.warn('requirements.txt found but bandit was not found in $PATH')
+    if (isPythonProject && !hasCommand) {
+      logger.warn('Python files were found but bandit was not found in $PATH')
       logger.warn(`${key} will not run unless you install bandit`)
       logger.warn('Please see: https://github.com/openstack/bandit')
       return false
     }
-    return hasRequirementsFile
+    return isPythonProject
   },
   run: async fm => {
     let banditCommand = 'bandit -r . -f json'


### PR DESCRIPTION
# Description

Run python-bandit module when *.py files are present, and stop checking for requirements.txt

Fixes #90 

# Type of change

[Please delete options that are not relevant.]

- [x] Bug fix (non-breaking change which fixes an issue)

# Toolchain

- [ ] Generic
- [ ] Java
- [ ] JavaScript
- [ ] Ruby
- [x] Python
- [ ] Other

# How Has This Been Tested?

[Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.  List any dependencies that are required for this change.]

**Test Configuration**:
* Toolchain:
* SDK (incl. version):
* OS version:
* Relevant links (e.g. a proof-of-concept repo to test-drive the changes):

# Notes for reviewer

[Where should a reviewer start? Delete this section if irrelevant.]

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
