### PR TITLE
Extend java-find-secbugs module to include package and class name in error code

### DIFF
--- a/lib/modules/java-find-secbugs/__tests__/findsecbugs-unit.js
+++ b/lib/modules/java-find-secbugs/__tests__/findsecbugs-unit.js
@@ -84,7 +84,7 @@ describe('FindSecBugs Module', () => {
     const results = await run(fm)
 
     expect(results.results.high).to.deep.equal([{
-      code: 'java-find-secbugs-XML_DECODER',
+      code: 'java-find-secbugs-XML_DECODER-com.hawkeye.java.test.controller.MyVulnerableControllerClass',
       offender: 'In method com.hawkeye.java.test.controller.MyVulnerableControllerClass.Update(int, UpdateCommand, BindingResult)',
       description: 'It is not safe to use an XMLDecoder to parse user supplied data',
       mitigation: 'Check line(s) [47-48]'
@@ -102,7 +102,7 @@ describe('FindSecBugs Module', () => {
     const results = await run(fm)
 
     expect(results.results.medium).to.deep.equal([{
-      code: 'java-find-secbugs-PREDICTABLE_RANDOM',
+      code: 'java-find-secbugs-PREDICTABLE_RANDOM-com.hawkeye.java.test.config.MyVulnerableConfigClass',
       offender: 'In method com.hawkeye.java.test.config.MyVulnerableConfigClass.generateSecretToken()',
       description: 'The use of java.util.Random is predictable',
       mitigation: 'Check line(s) 30'
@@ -120,7 +120,7 @@ describe('FindSecBugs Module', () => {
     const results = await run(fm)
 
     expect(results.results.low).to.deep.equal([{
-      code: 'java-find-secbugs-CRLF_INJECTION_LOGS',
+      code: 'java-find-secbugs-CRLF_INJECTION_LOGS-com.hawkeye.java.Application',
       description: 'This use of Logger.info(...) might be used to include CRLF characters into log messages',
       mitigation: 'Check line(s) 50, 55, 57, 59, 60, 61',
       offender: 'In method com.hawkeye.java.Application.main(String[])'

--- a/lib/modules/java-find-secbugs/index.js
+++ b/lib/modules/java-find-secbugs/index.js
@@ -52,7 +52,7 @@ module.exports = {
     const bugs = _.get(findSecBugsResult, ['BugCollection', 'BugInstance'], [])
     return bugs.map(bug => ({
       level: getSeverity(bug.$.priority),
-      code: bug.$.type,
+      code: bug.$.type + '-' + _.get(bug, ['Class', '0', '$', 'classname'], ''),
       offender: bug.Method[0].Message[0],
       description: bug.LongMessage[0],
       mitigation: getMitigationMessage(bug.SourceLine)


### PR DESCRIPTION
# Description

At the moment, java-find-secbugs only allows users to exclude findings based on the the type of bug-pattern. Since the same finding can be a false positive in one part of the code (esp. since findsecbugs also includes library code) but a real problem in another, this PR adds the package
and classname to the error code. 

Fixes #107 

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# Toolchain

- [x] Java
- [x] Kotlin

# How Has This Been Tested?

* Rebuild the Hawkeye Container to get all the tools
  ```
  $ docker build -t hawkeye-new .
  ```

* Get a Spring Boot project where findsecbugs detects problems in the library
  ```
  $ curl https://start.spring.io/starter.tgz \
           -d type=gradle-project \
           -d baseDir=spring-boot-java-gradle \
           -d language=java | tar -xzvf -
  $ cd spring-boot-java-gradle
  $ ./gradlew build
  ```

* Run Hawkeye against the project. You should see some findings from find-secbugs about spring boot internals and see the extended code
  ```
  $ docker run --rm -v $PWD:/target hawkeye-new scan --show-code -m java-find-secbugs
  ```

* Run Hawkeye again, this time excluding `org.springframework`. Hawkeye should come back without findings
  ```
  $ docker run --rm -v $PWD:/target hawkeye-new scan --show-code -m java-find-secbugs  --exclude '.*-org\.springframework.*'
  ```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (no related documentation)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
