### PR TITLE
pin ruby gem versions to allow docker build due to old ruby on centos7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN yum -y -q clean all
 RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 RUN python get-pip.py
 
-RUN gem install bundler-audit brakeman
+RUN gem install bundler:1.17.3 bundler-audit brakeman:4.4.0
 RUN bundle-audit update
 
 RUN pip install safety==1.8.4 piprot==0.9.10 bandit==1.5.1


### PR DESCRIPTION
# Description

pin ruby gem versions and unbreak docker build

Fixes #111 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Toolchain

- [ ] Generic
- [ ] Java
- [ ] JavaScript
- [x] Ruby
- [x] Docker
- [ ] Python
- [ ] Other
