### PR TITLE
Rust support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,10 @@ RUN cd /usr/local/bin && \
     wget --quiet https://get.sensiolabs.org/security-checker.phar && \
     chmod +x security-checker.phar
 
+ENV RUSTUP_HOME=/usr/local/opt/rust
+ENV CARGO_HOME=$RUSTUP_HOME
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH=/root/.cargo/bin:$PATH
+ENV PATH=$CARGO_HOME/bin:$PATH
 RUN cargo install cargo-audit && \
     rustc --version && cargo --version && cargo audit --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,11 @@ RUN cd /usr/local/bin && \
     wget --quiet https://get.sensiolabs.org/security-checker.phar && \
     chmod +x security-checker.phar
 
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH=/root/.cargo/bin:$PATH
+RUN cargo install cargo-audit && \
+    rustc --version && cargo --version && cargo audit --version
+
 RUN mkdir -p /hawkeye
 COPY ./ /hawkeye
 RUN cd /hawkeye && \

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Hawkeye scanner-cli assumes that your directory structure is such that it ke
 * **Kotlin** projects will have a `build` (gradle) or `target` (maven) folder, and include `.kt` and `.jar` files
 * **Scala** projects will have a `target` (sbt with `sbt-native-packager` or `sbt-assembly` plugins) folder, and include 
 `.scala` and `.jar` files. Check [this repo](https://github.com/csokol/scala-hawkeyesec-scanner-demo) for a running demo. 
+* **Rust** projects will have a `Cargo.toml` on top level
 
 This is not exhaustive as sometimes tools require further files to exist. To understand how the modules decide whether they can handle a project, please check the [How it works](https://github.com/hawkeyesec/scanner-cli#how-it-works) section and the [modules](lib/modules) folder.
 
@@ -272,6 +273,10 @@ Modules are basically little bits of code that either implement their own logic,
 
 * **ruby-brakeman**: Statically analyzes Rails code for security issues with Brakeman.
 * **ruby-bundler-scan**: Scan for Ruby gems with known vulnerabilities using bundler
+
+#### Rust
+
+* **rust-cargoaudit**: Checks whether the `Cargo.lock` contains dependencies with known vulnerabilities using [cargo audit](https://github.com/RustSec/cargo-audit)
 
 #### Adding a module
 

--- a/lib/modules/rust-cargoaudit/__tests__/cargoaudit-unit.js
+++ b/lib/modules/rust-cargoaudit/__tests__/cargoaudit-unit.js
@@ -83,10 +83,10 @@ describe('cargo audit Module', () => {
 
     expect(results.critical).to.have.length(1)
     expect(results.critical[0]).to.deep.equal({
-      'code': 'rust-cargoaudit-RUSTSEC-2018-0002',
-      'description': 'Links in archives can overwrite any existing file (https://github.com/alexcrichton/tar-rs/pull/156)',
-      'mitigation': 'Update "tar" crate to one of the following versions: >= 0.4.16',
-      'offender': 'tar=0.4.5'
+      code: 'rust-cargoaudit-RUSTSEC-2018-0002',
+      description: 'Links in archives can overwrite any existing file (https://github.com/alexcrichton/tar-rs/pull/156)',
+      mitigation: 'Update "tar" crate to one of the following versions: >= 0.4.16',
+      offender: 'tar=0.4.5'
     })
   })
 })

--- a/lib/modules/rust-cargoaudit/__tests__/cargoaudit-unit.js
+++ b/lib/modules/rust-cargoaudit/__tests__/cargoaudit-unit.js
@@ -1,0 +1,92 @@
+'use strict'
+
+const path = require('path')
+const { handles, run } = require('..')
+const exec = require('../../../exec')
+const FileManager = require('../../../file-manager')
+const auditReport = require('./sample/auditreport.json')
+const fs = require('fs')
+
+/* eslint-disable no-unused-expressions */
+
+describe('cargo audit Module', () => {
+  const targetWithLockFile = path.join(__dirname, 'sample', 'default')
+  const targetNoLock = path.join(__dirname, 'sample', 'no-lock-file')
+  let fmWithLockFile
+  let fmNoLock
+
+  function givenCargoInstalled () {
+    sinon.stub(exec, 'exists').withArgs('cargo').resolves(true)
+  }
+
+  function givenCargoAuditReturnsReport (auditReport) {
+    exec.command.withArgs('cargo audit --json').resolves({ stdout: JSON.stringify(auditReport) })
+  }
+
+  function givenCargoCanGenerateLockFile () {
+    exec.command.withArgs('cargo generate-lockfile').resolves({ stdout: '' })
+  }
+
+  function givenModuleCanRemoveLockFile () {
+    fs.unlinkSync.withArgs('Cargo.lock').returns(undefined)
+  }
+
+  beforeEach(() => {
+    sinon.stub(exec, 'command')
+    sinon.stub(fs, 'unlinkSync')
+    givenCargoInstalled()
+    fmWithLockFile = new FileManager({ target: targetWithLockFile })
+    fmNoLock = new FileManager({ target: targetNoLock })
+  })
+
+  it('should handle Rust projects with Cargo.lock file', async () => {
+    expect(await handles(fmWithLockFile)).to.be.true
+  })
+
+  it('should handle Rust projects with NO Cargo.lock file', async () => {
+    expect(await handles(fmNoLock)).to.be.true
+  })
+
+  it('should execute cargo generate-lockfile if no lock file present', async () => {
+    givenCargoAuditReturnsReport(auditReport)
+    givenCargoCanGenerateLockFile()
+    givenModuleCanRemoveLockFile()
+
+    await run(fmNoLock)
+
+    expect(exec.command.withArgs('cargo generate-lockfile')).to.have.been.calledOnce
+  })
+
+  it('should remove lock file after execution if no lock file present', async () => {
+    givenCargoAuditReturnsReport(auditReport)
+    givenCargoCanGenerateLockFile()
+    givenModuleCanRemoveLockFile()
+
+    await run(fmNoLock)
+
+    expect(fs.unlinkSync.withArgs(path.join(fmNoLock.target, 'Cargo.lock'))).to.have.been.calledAfter(exec.command.withArgs('cargo audit --json'))
+  })
+
+  it('should NOT remove lock file after execution if lock file IS present', async () => {
+    givenCargoAuditReturnsReport(auditReport)
+    givenModuleCanRemoveLockFile()
+
+    await run(fmWithLockFile)
+
+    expect(fs.unlinkSync.withArgs('Cargo.lock')).to.have.not.been.called
+  })
+
+  it('should report critical severity vulnerabilities', async () => {
+    givenCargoAuditReturnsReport(auditReport)
+
+    const { results } = await run(fmWithLockFile)
+
+    expect(results.critical).to.have.length(1)
+    expect(results.critical[0]).to.deep.equal({
+      'code': 'rust-cargoaudit-RUSTSEC-2018-0002',
+      'description': 'Links in archives can overwrite any existing file (https://github.com/alexcrichton/tar-rs/pull/156)',
+      'mitigation': 'Update "tar" crate to one of the following versions: >= 0.4.16',
+      'offender': 'tar=0.4.5'
+    })
+  })
+})

--- a/lib/modules/rust-cargoaudit/__tests__/sample/auditreport.json
+++ b/lib/modules/rust-cargoaudit/__tests__/sample/auditreport.json
@@ -1,0 +1,47 @@
+{
+  "database": {
+    "advisory-count": 31
+  },
+  "lockfile": {
+    "dependency-count": 6,
+    "path": "Cargo.lock"
+  },
+  "vulnerabilities": {
+    "count": 1,
+    "found": true,
+    "list": [
+      {
+        "advisory": {
+          "affected_arch": null,
+          "affected_functions": null,
+          "affected_os": null,
+          "aliases": [],
+          "date": "2018-06-29",
+          "description": "Some\nlong\ndescription",
+          "id": "RUSTSEC-2018-0002",
+          "keywords": [
+            "file-overwrite"
+          ],
+          "package": "tar",
+          "patched_versions": [
+            ">= 0.4.16"
+          ],
+          "references": [],
+            "title": "Links in archives can overwrite any existing file",
+          "unaffected_versions": [],
+          "url": "https://github.com/alexcrichton/tar-rs/pull/156"
+        },
+        "package": {
+          "dependencies": [
+            "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+            "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)"
+          ],
+          "name": "tar",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "version": "0.4.5"
+        }
+      }
+    ]
+  }
+}
+

--- a/lib/modules/rust-cargoaudit/__tests__/sample/default/Cargo.lock
+++ b/lib/modules/rust-cargoaudit/__tests__/sample/default/Cargo.lock
@@ -1,0 +1,47 @@
+[[package]]
+name = "cfg-if"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "filetime"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sample"
+version = "0.1.0"
+dependencies = [
+ "tar 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f"
+"checksum libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)" = "3262021842bf00fe07dbd6cf34ff25c99d7a7ebef8deea84db72be3ea3bb0aff"
+"checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+"checksum tar 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b9d327376c6bb766d5eaf130784a331c91aa093ef7b2a977377c9bc93cebf0e1"

--- a/lib/modules/rust-cargoaudit/__tests__/sample/default/Cargo.toml
+++ b/lib/modules/rust-cargoaudit/__tests__/sample/default/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "sample"
+version = "0.1.0"
+authors = ["Aleksei Bekh-Ivanov <bekh6ex@users.noreply.github.com>"]
+edition = "2018"
+
+[dependencies]
+tar="=0.4.5"

--- a/lib/modules/rust-cargoaudit/__tests__/sample/default/src/lib.rs
+++ b/lib/modules/rust-cargoaudit/__tests__/sample/default/src/lib.rs
@@ -1,0 +1,1 @@
+// Dummy file to make cargo generate Cargo.lock file

--- a/lib/modules/rust-cargoaudit/__tests__/sample/no-lock-file/Cargo.toml
+++ b/lib/modules/rust-cargoaudit/__tests__/sample/no-lock-file/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "sample"
+version = "0.1.0"
+authors = ["Aleksei Bekh-Ivanov <bekh6ex@users.noreply.github.com>"]
+edition = "2018"
+
+[dependencies]
+tar="=0.4.5"

--- a/lib/modules/rust-cargoaudit/__tests__/sample/no-lock-file/src/lib.rs
+++ b/lib/modules/rust-cargoaudit/__tests__/sample/no-lock-file/src/lib.rs
@@ -1,0 +1,1 @@
+// Dummy file to make cargo generate Cargo.lock file

--- a/lib/modules/rust-cargoaudit/index.js
+++ b/lib/modules/rust-cargoaudit/index.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+const ModuleResults = require('../../results')
+const exec = require('../../exec')
+const logger = require('../../logger')
+
+const key = __dirname.split(path.sep).pop()
+
+module.exports = {
+  key,
+  description: 'Checks Rust projects for dependencies with known vulnerabilities',
+  enabled: true,
+  handles: async fm => {
+    const isRustProject = fs.existsSync(path.join(fm.target, 'Cargo.toml'))
+    const hasCommand = await exec.exists('cargo')
+
+    if (isRustProject && !hasCommand) {
+      logger.warn('Cargo.lock found but cargo was not found in $PATH')
+      logger.warn(`${key} scan will not run unless you install cargo`)
+      return false
+    }
+
+    return isRustProject
+  },
+  run: async fm => {
+    let lockFileWasGeneratedByTheModule = false
+    try {
+      if (!fs.existsSync(path.join(fm.target, 'Cargo.lock'))) {
+        await exec.command('cargo generate-lockfile', { cwd: fm.target })
+        lockFileWasGeneratedByTheModule = true
+      }
+      const { stdout } = await exec.command('cargo audit --json', { cwd: fm.target })
+      const report = JSON.parse(stdout)
+      const vulnerabilities = report.vulnerabilities.list
+
+      return vulnerabilities
+        .map(v => {
+          const adv = v.advisory
+          const pkg = v.package
+          const patchedVersionsText = adv.patched_versions.join(', ')
+          return {
+            offender: `${pkg.name}=${pkg.version}`,
+            code: adv.id,
+            description: `${adv.title} (${adv.url})`,
+            mitigation: `Update "${adv.package}" crate to one of the following versions: ${patchedVersionsText}`
+          }
+        })
+        .reduce((results, v) => results.critical(v), new ModuleResults(key))
+    } finally {
+      if (lockFileWasGeneratedByTheModule) {
+        fs.unlinkSync(path.join(fm.target, 'Cargo.lock'))
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

Add new module that wraps [cargo audit](https://github.com/RustSec/cargo-audit) for checking dependency versions in Cargo.lock against known vulnerabilities.

Fixes #100 

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# Toolchain

- [x] Other (Rust)

# How Has This Been Tested?

  * Unit tests in `/lib/modules/rust-cargoaudit/__tests__/cargoaudit-unit.js`
  * Using Docker image on test sample directories
  * Using locally installed Rust toolchain on test sample directories

**Test Configuration**:
* Toolchain: cargo-audit 0.6.1
* SDK (incl. version): rustc/cargo version 1.33.0 and 1.36.0
* OS version: MacOS
* Relevant links (e.g. a proof-of-concept repo to test-drive the changes): project directories `/lib/modules/rust-cargoaudit/__tests__/sample/default` and `/lib/modules/rust-cargoaudit/__tests__/sample/no-lock-file`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
