### PR TITLE
Create module to find outdated dependencies of maven projects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN yum -y -q install wget epel-release openssl openssl-devel tar unzip \
 			  libffi-devel python-devel redhat-rpm-config git-core \
 			  gcc gcc-c++ make zlib-devel pcre-devel \
         java-1.8.0-openjdk.x86_64 which \
-        php php-cli
+        php php-cli \
+        maven
 
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
 

--- a/lib/__tests__/exec-unit.js
+++ b/lib/__tests__/exec-unit.js
@@ -34,6 +34,12 @@ describe('exec', () => {
       }
       expect(thrown).to.be.true
     })
+
+    it('should execute command ignoring stdout', async () => {
+      const { code, stderr } = await command('pwd', { stdio: ['ignore', 'ignore', 'pipe'] })
+      expect(code).to.equal(0)
+      expect(stderr).to.be.empty
+    })
   })
 
   describe('commandSync', () => {

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -10,7 +10,10 @@ const command = (command, options = {}) => new Promise(function (resolve, reject
   let stderr = ''
 
   const proc = spawn(root, args, options)
-  proc.stdout.on('data', data => { stdout += data.toString() })
+  if (proc.stdout) { // when stout is flagged 'ignored' in the options, proc.stdout is null
+    proc.stdout.on('data', data => { stdout += data.toString() })
+  }
+
   proc.stderr.on('data', data => { stderr += data.toString() })
 
   proc.on('error', err => {

--- a/lib/modules/java-outdated-dependencies/__tests__/java-outdated-dependencies-unit.js
+++ b/lib/modules/java-outdated-dependencies/__tests__/java-outdated-dependencies-unit.js
@@ -1,0 +1,65 @@
+'use strict'
+
+/* eslint-disable no-unused-expressions */
+
+const path = require('path')
+const exec = require('../../../exec')
+const FileManager = require('../../../file-manager')
+const { run, handles } = require('..')
+
+describe('Java outdated dependencies module', () => {
+  const mvnOutput = path.join(__dirname, './sample/mvnOutput.txt')
+
+  beforeEach(() => {
+    sinon.stub(exec, 'command').resolves({ stdout: '' })
+  })
+
+  it('should run on maven java projects', async () => {
+    sinon.stub(exec, 'exists').resolves(true)
+
+    const target = path.join(__dirname, './sample/java-maven')
+    const fm = new FileManager({ target })
+
+    expect(await handles(fm)).to.be.true
+  })
+
+  it('should not run if mvn is executable is not available', async () => {
+    sinon.stub(exec, 'exists').resolves(false)
+
+    const target = path.join(__dirname, './sample/java-maven')
+    const fm = new FileManager({ target })
+
+    expect(await handles(fm)).to.be.false
+  })
+
+  it('should execute maven versions plugin', async () => {
+    const target = path.join(__dirname, './sample/java-maven')
+    const fm = new FileManager({ target })
+
+    await run(fm, mvnOutput)
+
+    expect(exec.command.firstCall.args[0]).to.equal(`mvn --batch-mode versions:display-dependency-updates -Dversions.outputFile=${mvnOutput}`)
+    expect(exec.command.firstCall.args[1]).to.deep.equal({ cwd: target, stdio: ['ignore', 'ignore', 'pipe'] })
+  })
+
+  it('should parse maven report', async () => {
+    const target = path.join(__dirname, './sample/java-maven')
+    const fm = new FileManager({ target })
+
+    const { results } = await run(fm, mvnOutput)
+
+    expect(results.low).to.deep.contain({
+      code: 'java-outdated-dependencies-antlr:antlr',
+      offender: 'antlr:antlr:2.7.7',
+      description: '',
+      mitigation: 'Update to antlr:antlr 20030911'
+    })
+
+    expect(results.low).to.deep.contain({
+      code: 'java-outdated-dependencies-com.microsoft.sqlserver:mssql-jdbc',
+      offender: 'com.microsoft.sqlserver:mssql-jdbc:6.4.0.jre8',
+      description: '',
+      mitigation: 'Update to com.microsoft.sqlserver:mssql-jdbc 7.3.1.jre12-preview'
+    })
+  })
+})

--- a/lib/modules/java-outdated-dependencies/__tests__/sample/mvnOutput.txt
+++ b/lib/modules/java-outdated-dependencies/__tests__/sample/mvnOutput.txt
@@ -1,0 +1,8 @@
+The following dependencies in Dependency Management have newer versions:
+  antlr:antlr ........................................ 2.7.7 -> 20030911
+  com.microsoft.sqlserver:mssql-jdbc ...
+                                       6.4.0.jre8 -> 7.3.1.jre12-preview
+  com.rabbitmq:amqp-client .............................. 5.4.3 -> 5.7.2
+  xml-apis:xml-apis .................................... 1.4.01 -> 2.0.2
+
+No dependencies in pluginManagement of plugins have newer versions.

--- a/lib/modules/java-outdated-dependencies/index.js
+++ b/lib/modules/java-outdated-dependencies/index.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const { existsSync, readFileSync } = require('fs')
+const path = require('path')
+const exec = require('../../exec')
+const ModuleResults = require('../../results')
+const logger = require('../../logger')
+const tmp = require('tmp')
+
+const key = __dirname.split(path.sep).pop()
+module.exports = {
+  key,
+  description: '',
+  enabled: true,
+  handles: async fm => {
+    const allFiles = fm.all()
+
+    const isMavenProject = allFiles.some(file => file === 'pom.xml')
+    const hasCommand = await exec.exists('mvn')
+
+    if (isMavenProject && !hasCommand) {
+      logger.warn('pom.xml found but mvn executable was not found in $PATH')
+      logger.warn(`java-outdated-dependencies will not run unless you install Maven`)
+      return false
+    }
+
+    return isMavenProject
+  },
+  run: async (fm, reportFile) => {
+    reportFile = reportFile || path.resolve(tmp.dirSync().name, 'report.txt')
+    const results = new ModuleResults(key)
+    const data = await exec.command(`mvn --batch-mode versions:display-dependency-updates -Dversions.outputFile=${reportFile}`, { cwd: fm.target, stdio: ['ignore', 'ignore', 'pipe'] })
+
+    if (!existsSync(reportFile)) {
+      throw new Error(`There was an error while executing maven versions plugin and the report was not created: ${JSON.stringify(data.stderr || data.stdout)}`)
+    }
+
+    const report = readFileSync(reportFile)
+
+    const lines = report.toString().trim().split('\n')
+
+    const depedencyLineRegex = /(\S+)\s\.+\s(\S+)\s->\s(\S+)/
+    const dependenciesLines = lines.slice(1, lines.length - 2)
+
+    for (let i = 0; i < dependenciesLines.length; i++) {
+      let line = dependenciesLines[i]
+      if (!line.includes('->')) { // the jar name is too long to fit in one line so maven breaks that up in two lines
+        line = `${line} ${dependenciesLines[i + 1].trim()}`
+        i++
+      }
+      const matches = line.match(depedencyLineRegex)
+      results.low(
+        {
+          code: `${matches[1]}`,
+          offender: `${matches[1]}:${matches[2]}`,
+          description: '',
+          mitigation: `Update to ${matches[1]} ${matches[3]}`
+        }
+      )
+    }
+    return results
+  }
+}


### PR DESCRIPTION
# Description

Use [maven versions plugin](https://www.mojohaus.org/versions-maven-plugin/) to find outdated java dependencies in maven projects.

This partially addresses #87 

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# Toolchain

- [x] Java

# How Has This Been Tested?

Build the docker image:

```bash
docker build . -t hawkeyesec/scanner-cli:maven-deps
```

Then run it against a java project:

```bash
curl https://start.spring.io/starter.tgz \
         -d type=maven-project \
         -d baseDir=spring-boot-java-maven \
         -d language=java | tar -xzvf -

cd spring-boot-java-maven
cat << EOF > .hawkeyerc
{
  "all": true,
  "modules": ["java-outdated-dependencies"],
  "json": "results.json"
}
EOF

docker run --rm -v /Users/csokol/.m2/:/root/.m2 -v $PWD:/target hawkeyesec/scanner-cli:maven-deps

```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
