### PR TITLE
Update file-manager.js

### DIFF
--- a/lib/file-manager.js
+++ b/lib/file-manager.js
@@ -11,7 +11,7 @@ module.exports = class FileManager {
   constructor ({ target, staged, all, exclude = [] }) {
     this.target = target
     this.exclude = exclude
-    this.targetRegex = new RegExp(`^${this.target}/?`)
+    this.targetRegex = new RegExp(`^${this.target.replace(new RegExp(/\\/, 'g'), '\\\\')}/?`)
     this.files = {}
 
     const gitRepo = path.join(this.target, '.git')


### PR DESCRIPTION
# Description

Hawkeye scanner does not run on Windows.
When certain modules run (eg: java-find-secbugs) the file-manager tries to get all files (getAllFilesSync). It replaces the filePath with a regex to produce a relative path
`const relativePath = filePath.replace(this.targetRegex, '')`.
This doesn't work on Windows as the \ in the directory is a escape character. Reg ex fails and you end up with a path something like this:
D:\Code\D:\Code\Folder\ rather than D:\Code\Folder\

Fixes #131

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Toolchain
- [x] JavaScript

# How Has This Been Tested?

[Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.  List any dependencies that are required for this change.]

**Test Configuration**: `hawkeye scan`
* Toolchain:
* SDK (incl. version): "^1.6.2"
* OS version: Windows 10
* Relevant links https://github.com/SeanC4/scanner-cli


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
