### PR TITLE
Enhancement [file-contents]: Relax rule to match 'password' case insensitive

### DIFF
--- a/lib/modules/files-contents/data.js
+++ b/lib/modules/files-contents/data.js
@@ -2,7 +2,7 @@
 module.exports = [
   {
     code: 1,
-    regex: /(['|"]?password['|"]? ?[:|=] ?['|"]?.*['|"]?)/,
+    regex: /(['|"]?password['|"]? ?[:|=] ?['|"]?.*['|"]?)/i,
     description: 'Potential password in file',
     level: 'low'
   },


### PR DESCRIPTION
# Description

Enable file-contents match on 'password' (code 1) to be case insensitive

# Type of change

[Please delete options that are not relevant.]

- [x ] New feature (non-breaking change which adds functionality)

# Toolchain

- [x ] Generic

# How Has This Been Tested?

Nill / ruleset only.

# Issue

Scanner was not identifying file with line:

`PASSWORD="foo"`

but did identify

`password="foo"`
