### PR TITLE
Update security-checker.phar download link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN mkdir $OWASP_DEP_FOLDER && cd $OWASP_DEP_FOLDER && \
 ENV PATH $OWASP_DEP_FOLDER/dependency-check/bin:$PATH
 
 RUN cd /usr/local/bin && \
-    wget --quiet https://get.sensiolabs.org/security-checker.phar && \
+    wget --quiet https://www.laravel-enlightn.com/security-checker.phar && \
     chmod +x security-checker.phar
 
 COPY --from=cargo-audit-build /home/rust/bin/ /usr/local/bin/


### PR DESCRIPTION
# Description

Updated the security-checker.phar file download link from Sensiolabs which has been deprecated and is inaccessible now.

Fixes #167

# Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Toolchain

- [X] Generic

# How Has This Been Tested?

* Download the project
* Run the docker build command
* Check if the docker image is built correctly without any wget errors

**Test Configuration**:
* Toolchain: Docker, ZSH
* OS version: macOS Catalina 10.15.7

# Checklist:

No code changes required, an update was made to the Dockerfile

- [X] I have performed a self-review of my own code
